### PR TITLE
Add Windows version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ config.codekit
 **/.sass-cache/*
 
 media/*
+
+Scripts/*
+Lib/*
+tcl/*

--- a/Install-Jurymatic.ps1
+++ b/Install-Jurymatic.ps1
@@ -1,0 +1,48 @@
+<#
+    .NOTES
+        Coded with <3 by @rasmuskriest and @wolfskaempf
+    
+    .SYNOPSIS
+        The final solution for creating jury booklets for events of the European Youth Parliament.
+
+    .DESCRIPTION
+        The final solution for creating jury booklets for events of the European Youth Parliament. This is script one out of two which is meant to install a new JURYMATIC instance.
+
+    .EXAMPLE
+        .\Install-Jurymatic.ps1
+#>
+#Requires -Version 3.0
+
+echo "Welcome to the jurymatic installer!
+   _                                  _   _
+  (_)_   _ _ __ _   _ _ __ ___   __ _| |_(_) ___
+  | | | | | '__| | | | '_ ` _ \ / _` | __| |/ __|
+  | | |_| | |  | |_| | | | | | | (_| | |_| | (__
+ _/ |\__,_|_|   \__, |_| |_| |_|\__,_|\__|_|\___|
+|__/            |___/"
+
+echo "=============================="
+echo "This file will start the installation process in an elevated PowerShell."
+echo "=============================="
+
+python.exe $PSScriptRoot\get-pip.py
+
+pip install virtualenv
+
+virtualenv $PSScriptRoot
+
+iex .\Scripts\activate.ps1
+
+pip install -r requirements.txt
+
+python manage.py migrate
+
+echo "============================="
+
+echo "We are now going to create the administration user for the jurymatic server. Please remember the details you enter here. Only username and password are required fields."
+
+echo "============================="
+
+python manage.py createsuperuser
+
+echo "Congratulations, you are done. You can now run start.bat or Start-Jurymatic.ps1 respectively."

--- a/Install-Jurymatic.ps1
+++ b/Install-Jurymatic.ps1
@@ -13,7 +13,7 @@
 #>
 #Requires -Version 3.0
 
-echo "Welcome to the jurymatic installer!
+Write-Output "Welcome to the jurymatic installer!
    _                                  _   _
   (_)_   _ _ __ _   _ _ __ ___   __ _| |_(_) ___
   | | | | | '__| | | | '_ ` _ \ / _` | __| |/ __|
@@ -21,9 +21,9 @@ echo "Welcome to the jurymatic installer!
  _/ |\__,_|_|   \__, |_| |_| |_|\__,_|\__|_|\___|
 |__/            |___/"
 
-echo "=============================="
-echo "This file will start the installation process in an elevated PowerShell."
-echo "=============================="
+Write-Output "=============================="
+Write-Output "This file will start the installation process."
+Write-Output "=============================="
 
 python.exe $PSScriptRoot\get-pip.py
 
@@ -31,18 +31,18 @@ pip install virtualenv
 
 virtualenv $PSScriptRoot
 
-iex .\Scripts\activate.ps1
+Invoke-Expression .\Scripts\activate.ps1
 
 pip install -r requirements.txt
 
-python manage.py migrate
+python.exe manage.py migrate
 
-echo "============================="
+Write-Output "============================="
 
-echo "We are now going to create the administration user for the jurymatic server. Please remember the details you enter here. Only username and password are required fields."
+Write-Output "We are now going to create the administration user for the jurymatic server. Please remember the details you enter here. Only username and password are required fields."
 
-echo "============================="
+Write-Output "============================="
 
-python manage.py createsuperuser
+python.exe manage.py createsuperuser
 
-echo "Congratulations, you are done. You can now run start.bat or Start-Jurymatic.ps1 respectively."
+Write-Output "Congratulations, you are done. You can now run start.bat or Start-Jurymatic.ps1 respectively."

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ If you like watching video tutorials, you can have a look at this [playlist of v
 
 _You need at least version 3.0 of PowerShell. It is built-in starting from Windows 8. If you are using Windows 7 or lower, you will have to upgrade PowerShell to the latest version._
 
+As Windows is not being shipped with Python 2, you have to install the software manually before using _Jurymatic_. To make this as easy as possible, you can just double-click the included file `install-prerequisites.bat`. If your default browser is not _Internet Explorer_ or _Edge_ please copy and paste the following URL into either manually: `http://boxstarter.org/package/nr/python2`
+
 1. Download the latest release from the releases section.
 2. Unpack it and open the folder it contains.
 3. Double-click on `install.cmd`.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you like watching video tutorials, you can have a look at this [playlist of v
 
 ### Windows
 
-_You need at least version 3.0 of PowerShell. It is built-in starting from Windows 8. If you are using Windows 7 or lower, you will have to upgrade PowerShell to the latest version._You
+_You need at least version 3.0 of PowerShell. It is built-in starting from Windows 8. If you are using Windows 7 or lower, you will have to upgrade PowerShell to the latest version._
 
 1. Download the latest release from the releases section.
 2. Unpack it and open the folder it contains.

--- a/README.md
+++ b/README.md
@@ -16,9 +16,7 @@ If you like watching video tutorials, you can have a look at this [playlist of v
 
 ### Windows
 
-_You need at least version 3.0 of PowerShell. It is built-in starting from Windows 8. If you are using Windows 7 or lower, you will have to upgrade PowerShell to the latest version._
-
-As Windows is not being shipped with Python 2, you have to install the software manually before using _Jurymatic_. To make this as easy as possible, you can just double-click the included file `install-prerequisites.bat`. If your default browser is not _Internet Explorer_ or _Edge_ please copy and paste the following URL into either manually: `http://boxstarter.org/package/nr/python2`
+_Jurymatic_ requires both PowerShell (version 3.0 or newer) and Python 2 to work on Windows. Since neither are part of a standard installation, you have to install the software manually before using _Jurymatic_. To make this as easy as possible, you can just double-click the included file `install-prerequisites.bat`. If your default browser is not _Internet Explorer_ or _Edge_ please copy and paste the following URL into either manually: `http://boxstarter.org/package/nr/powershell,python2`
 
 1. Download the latest release from the releases section.
 2. Unpack it and open the folder it contains.

--- a/README.md
+++ b/README.md
@@ -6,14 +6,32 @@ The final solution for creating jury booklets for events of the European Youth P
 ## Installation
 If you like watching video tutorials, you can have a look at this [playlist of videos on how to use `jurymatic`](https://www.youtube.com/playlist?list=PLWqZWxSNRmk83SRJ2hx3tqCu2GrglyhFW). If you're not, here's the quick rundown.
 
+### macOS
+
 1. Download the latest release from the releases section.
 2. Unpack it and open the folder it contains.
 3. Right-click on `install.command` and click `Open`.
 4. Click `Open` again, indicating that you trust the source of the file.
 5. Follow the steps on the screen. Enter your computer's password when asked.
 
+### Windows
+
+_You need at least version 3.0 of PowerShell. It is built-in starting from Windows 8. If you are using Windows 7 or lower, you will have to upgrade PowerShell to the latest version._You
+
+1. Download the latest release from the releases section.
+2. Unpack it and open the folder it contains.
+3. Double-click on `install.cmd`.
+4. Enter your computer's password when asked.
+
 ## Usage
-After you're done installing the program, you can right-click `start.command`, select `Open` twice and `jurymatic` will start.
+
+After you're done installing the program, you can easily start _Jurymatic_ each time you need it.
+
+**macOS**: Right-click `start.command`, select `Open` twice and `jurymatic` will start.
+
+**Windows**: Double-click on `start.cmd`
+
+### Windows
 
 ## Video Tutorials
 If you'd like to watch videos to understand how to use `jurymatic`, you can do so [here on YouTube](https://www.youtube.com/playlist?list=PLWqZWxSNRmk83SRJ2hx3tqCu2GrglyhFW).

--- a/Start-Jurymatic.ps1
+++ b/Start-Jurymatic.ps1
@@ -13,12 +13,12 @@
 #>
 #Requires -Version 3.0
 
-$localip = Test-Connection -ComputerName (hostname) -Count 1  | Select IPV4Address
+$localip = Test-Connection -ComputerName (hostname) -Count 1  | Select-Object IPV4Address
 
-echo "Your local IP address: ${localip}:8000"
+Write-Output "Your local IP address: ${localip}:8000"
 
-echo "=============================="
+Write-Output "=============================="
 
-iex .\Scripts\activate.ps1
-start http://localhost:8000
+Invoke-Expression .\Scripts\activate.ps1
+Start-Process http://localhost:8000
 python.exe $PSScriptRoot\manage.py runserver 0.0.0.0:8000

--- a/Start-Jurymatic.ps1
+++ b/Start-Jurymatic.ps1
@@ -1,0 +1,24 @@
+<#
+    .NOTES
+        Coded with <3 by @rasmuskriest and @wolfskaempf
+    
+    .SYNOPSIS
+        The final solution for creating jury booklets for events of the European Youth Parliament.
+
+    .DESCRIPTION
+        The final solution for creating jury booklets for events of the European Youth Parliament. This is script two out of two which is meant to start am installed JURYMATIC instance.
+
+    .EXAMPLE
+        .\Start-Jurymatic.ps1
+#>
+#Requires -Version 3.0
+
+$localip = Test-Connection -ComputerName (hostname) -Count 1  | Select IPV4Address
+
+echo "Your local IP address: ${localip}:8000"
+
+echo "=============================="
+
+iex .\Scripts\activate.ps1
+start http://localhost:8000
+python.exe $PSScriptRoot\manage.py runserver 0.0.0.0:8000

--- a/install-prerequisites.bat
+++ b/install-prerequisites.bat
@@ -2,4 +2,4 @@
 REM This will install any prerequisites for the installation of Jurymatic.
 REM Current prerequisites can be found in the README.md
 
-start http://boxstarter.org/package/nr/python2
+start http://boxstarter.org/package/nr/powershell,python2

--- a/install-prerequisites.bat
+++ b/install-prerequisites.bat
@@ -1,0 +1,5 @@
+@echo off
+REM This will install any prerequisites for the installation of Jurymatic.
+REM Current prerequisites can be found in the README.md
+
+start http://boxstarter.org/package/nr/python2

--- a/install.bat
+++ b/install.bat
@@ -1,0 +1,4 @@
+@echo off
+REM This will start the installation of Jurymatic in an elevated PowerShell.
+
+@powershell -NoProfile -ExecutionPolicy Bypass -Command "iex %cd%\Install-Jurymatic.ps1"

--- a/jurycore/templates/jurycore/_footer.html
+++ b/jurycore/templates/jurycore/_footer.html
@@ -1,6 +1,6 @@
 <div class="hidden-print container">
   <hr>
   <p>
-    <a class="credit" target="_blank" href="https://github.com/wolfskaempf"><span class="octicon octicon-code"></span> with <span class="octicon octicon-heart"></span> by @wolfskaempf</a>
+    <a class="credit" target="_blank" href="https://github.com/wolfskaempf"><span class="octicon octicon-code"></span> with <span class="octicon octicon-heart"></span> by @rasmuskriest and @wolfskaempf</a>
   </p>
 </div>

--- a/start.bat
+++ b/start.bat
@@ -1,0 +1,4 @@
+@echo off
+REM This will start Jurymatic in an elevated PowerShell.
+
+@powershell -NoProfile -ExecutionPolicy Bypass -Command "iex %cd%\Start-Jurymatic.ps1"


### PR DESCRIPTION
Since many users in the EYP use Windows computers, there is a need to be able to run _Jurymatic_ on Windows as well as macOS. The script `install-prerequisites.bat` installs PowerShell and Python 2 automatically through a Click-Once installer by @mwrock. Both `install.bat` and `start.bat` execute PowerShell scripts (`Install-Jurymatic.ps1` and `Start-Jurymatic.ps1`) that gurantee a _Jurymatic_ experience similar to the one on macOS. The README.md gives equally easy step-by-step instructions.