### PR TITLE
Make Windows version more reliable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ media/*
 Scripts/*
 Lib/*
 tcl/*
+.vscode/*

--- a/Install-Jurymatic.ps1
+++ b/Install-Jurymatic.ps1
@@ -25,15 +25,15 @@ Write-Output "=============================="
 Write-Output "This file will start the installation process."
 Write-Output "=============================="
 
-python.exe $PSScriptRoot\get-pip.py
+py.exe -2 $PSScriptRoot\get-pip.py
 
-pip install virtualenv
+pip2 install virtualenv
 
 virtualenv $PSScriptRoot
 
 Invoke-Expression .\Scripts\activate.ps1
 
-pip install -r requirements.txt
+pip2 install -r requirements.txt
 
 python.exe manage.py migrate
 
@@ -43,6 +43,6 @@ Write-Output "We are now going to create the administration user for the jurymat
 
 Write-Output "============================="
 
-python.exe manage.py createsuperuser
+py.exe -2 manage.py createsuperuser
 
 Write-Output "Congratulations, you are done. You can now run start.bat or Start-Jurymatic.ps1 respectively."

--- a/Install-Jurymatic.ps1
+++ b/Install-Jurymatic.ps1
@@ -1,6 +1,6 @@
 <#
     .NOTES
-        Script coded with <3 by @rasmuskriest
+        Script <> with <3 by @rasmuskriest
 
     .SYNOPSIS
         The final solution for creating jury booklets for events of the European Youth Parliament.
@@ -25,24 +25,52 @@ Write-Output "=============================="
 Write-Output "This file will start the installation process."
 Write-Output "=============================="
 
-python.exe $PSScriptRoot\get-pip.py
+if (Get-Command py.exe -errorAction SilentlyContinue) {
+    $Env:PY_PYTHON = 2
 
-pip install virtualenv
+    py.exe $PSScriptRoot\get-pip.py
 
-virtualenv $PSScriptRoot
+    pip install virtualenv
 
-Invoke-Expression .\Scripts\activate.ps1
+    virtualenv $PSScriptRoot
 
-pip install -r requirements.txt
+    Invoke-Expression .\Scripts\activate.ps1
 
-python.exe manage.py migrate
+    pip install -r requirements.txt
 
-Write-Output "============================="
+    py.exe manage.py migrate
 
-Write-Output "We are now going to create the administration user for the jurymatic server. Please remember the details you enter here. Only username and password are required fields."
+    Write-Output "============================="
+    Write-Output "We are now going to create the administration user for the jurymatic server. Please remember the details you enter here. Only username and password are required fields."
+    Write-Output "============================="
 
-Write-Output "============================="
+    py.exe manage.py createsuperuser
 
-python.exe manage.py createsuperuser
+    Write-Output "Congratulations, you are done. You can now run start.bat or Start-Jurymatic.ps1 respectively."
 
-Write-Output "Congratulations, you are done. You can now run start.bat or Start-Jurymatic.ps1 respectively."
+    Pause
+}
+
+else {
+    python.exe $PSScriptRoot\get-pip.py
+
+    pip install virtualenv
+
+    virtualenv $PSScriptRoot
+
+    Invoke-Expression .\Scripts\activate.ps1
+
+    pip install -r requirements.txt
+
+    python.exe manage.py migrate
+
+    Write-Output "============================="
+    Write-Output "We are now going to create the administration user for the jurymatic server. Please remember the details you enter here. Only username and password are required fields."
+    Write-Output "============================="
+
+    python.exe manage.py createsuperuser
+
+    Write-Output "Congratulations, you are done. You can now run start.bat or Start-Jurymatic.ps1 respectively."
+
+    Pause
+}

--- a/Install-Jurymatic.ps1
+++ b/Install-Jurymatic.ps1
@@ -25,15 +25,15 @@ Write-Output "=============================="
 Write-Output "This file will start the installation process."
 Write-Output "=============================="
 
-py.exe -2 $PSScriptRoot\get-pip.py
+python.exe $PSScriptRoot\get-pip.py
 
-pip2 install virtualenv
+pip install virtualenv
 
 virtualenv $PSScriptRoot
 
 Invoke-Expression .\Scripts\activate.ps1
 
-pip2 install -r requirements.txt
+pip install -r requirements.txt
 
 python.exe manage.py migrate
 
@@ -43,6 +43,6 @@ Write-Output "We are now going to create the administration user for the jurymat
 
 Write-Output "============================="
 
-py.exe -2 manage.py createsuperuser
+python.exe manage.py createsuperuser
 
 Write-Output "Congratulations, you are done. You can now run start.bat or Start-Jurymatic.ps1 respectively."

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you like watching video tutorials, you can have a look at this [playlist of v
 
 ### Windows
 
-`jurymatic` requires both PowerShell (version 3.0 or newer) and Python 2 to work on Windows. Since neither are part of a standard installation, you have to install the software manually before using `jurymatic`. To make this as easy as possible, you can just double-click the included file `install-prerequisites.bat`. If your default browser is not _Internet Explorer_ or _Edge_ please copy and paste the following URL into either manually: `http://boxstarter.org/package/nr/powershell,python2`
+`jurymatic` requires both PowerShell (version 3.0 or newer) and Python 2 to work on Windows. Since neither are part of a standard installation, you have to install the software manually before using `jurymatic`. To make this as easy as possible, you can just double-click the included file `install-prerequisites.bat`. If your default browser is not _Internet Explorer_ or _Edge_ please copy and paste the following URL into either manually: `http://boxstarter.org/package/nr/powershell,python2` You might have to confirm the installation and enter your (Administrator's) password. After the script has finished, restart your computer.
 
 1. Download the latest release from the releases section.
 2. Unpack it and open the folder it contains.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you like watching video tutorials, you can have a look at this [playlist of v
 
 ### Windows
 
-`jurymatic` requires both PowerShell (version 3.0 or newer) and Python 2 to work on Windows. Since neither are part of a standard installation, you have to install the software manually before using `jurymatic`. To make this as easy as possible, you can just double-click the included file `install-prerequisites.bat`. If your default browser is not _Internet Explorer_ or _Edge_ please copy and paste the following URL into either manually: `http://boxstarter.org/package/nr/powershell,python2` You might have to confirm the installation and enter your (Administrator's) password. After the script has finished, restart your computer.
+`jurymatic` requires both PowerShell (version 3.0 or newer) and Python 2 to work on Windows. Since neither are part of a standard installation, you have to install the software manually before using `jurymatic`. To make this as easy as possible, you can just double-click the included file `install-prerequisites.bat`. If your default browser is not _Internet Explorer_ or _Edge_ please copy and paste the following URL into either manually: `http://boxstarter.org/package/nr/dotnet4.5.1,powershell,python2` You might have to confirm the installation and enter your (Administrator's) password. After the script has finished, restart your computer.
 
 1. Download the latest release from the releases section.
 2. Unpack it and open the folder it contains.

--- a/Start-Jurymatic.ps1
+++ b/Start-Jurymatic.ps1
@@ -1,6 +1,6 @@
 <#
     .NOTES
-        Script coded with <3 by @rasmuskriest
+        Script <> with <3 by @rasmuskriest
 
     .SYNOPSIS
         The final solution for creating jury booklets for events of the European Youth Parliament.
@@ -16,9 +16,22 @@
 $localip = Test-Connection -ComputerName (hostname) -Count 1  | Select-Object IPV4Address
 
 Write-Output "Your local IP address: ${localip}:8000"
-
 Write-Output "=============================="
 
-Invoke-Expression .\Scripts\activate.ps1
-Start-Process http://localhost:8000
-python.exe $PSScriptRoot\manage.py runserver 0.0.0.0:8000
+if (Get-Command py.exe -errorAction SilentlyContinue) {
+    $Env:PY_PYTHON = 2
+
+    Invoke-Expression .\Scripts\activate.ps1
+
+    Start-Process http://localhost:8000
+
+    py.exe $PSScriptRoot\manage.py runserver 0.0.0.0:8000
+}
+
+else {
+    Invoke-Expression .\Scripts\activate.ps1
+
+    Start-Process http://localhost:8000
+    
+    python.exe $PSScriptRoot\manage.py runserver 0.0.0.0:8000
+}

--- a/Start-Jurymatic.ps1
+++ b/Start-Jurymatic.ps1
@@ -21,4 +21,4 @@ Write-Output "=============================="
 
 Invoke-Expression .\Scripts\activate.ps1
 Start-Process http://localhost:8000
-py.exe -2 $PSScriptRoot\manage.py runserver 0.0.0.0:8000
+python.exe $PSScriptRoot\manage.py runserver 0.0.0.0:8000

--- a/Start-Jurymatic.ps1
+++ b/Start-Jurymatic.ps1
@@ -21,4 +21,4 @@ Write-Output "=============================="
 
 Invoke-Expression .\Scripts\activate.ps1
 Start-Process http://localhost:8000
-python.exe $PSScriptRoot\manage.py runserver 0.0.0.0:8000
+py.exe -2 $PSScriptRoot\manage.py runserver 0.0.0.0:8000

--- a/install-prerequisites.bat
+++ b/install-prerequisites.bat
@@ -2,4 +2,4 @@
 REM This will install any prerequisites for the installation of Jurymatic.
 REM Current prerequisites can be found in the README.md
 
-start http://boxstarter.org/package/nr/powershell,python2
+start http://boxstarter.org/package/nr/dotnet4.5.1,powershell,python2


### PR DESCRIPTION
To make the installation of _PowerShell 5_ possible, _.NET 4.5.1_ is automatically installed (if not present) during the configuration of prerequisites. Since some users might have both Python 2 and 3 installed on their system, both `Install-Jurymatic.ps1` and `Start-Jurymatic.ps1` now include a check on whether this is the case and act accordingly to always use v2. `README.md` now states possible password prompts and needed reboots to match the macOS section as closely as possible.